### PR TITLE
fix: 회원가입 서비스 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,19 @@ dependencies {
     // JSTL (c:forEach 같은 거)
     implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0'
     runtimeOnly  'org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1'
+
+    // testContainer
+    testImplementation platform("org.testcontainers:testcontainers-bom:1.21.4")
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
+
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == "org.testcontainers") {
+                details.useVersion "1.21.4"
+            }
+        }
+    }
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,12 @@ dependencies {
     testImplementation platform("org.testcontainers:testcontainers-bom:1.21.4")
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+}
 
-    configurations.all {
-        resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == "org.testcontainers") {
-                details.useVersion "1.21.4"
-            }
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == "org.testcontainers") {
+            details.useVersion "1.21.4"
         }
     }
 }

--- a/src/main/java/com/example/clothsdanawa/ClothsDaNaWaApplication.java
+++ b/src/main/java/com/example/clothsdanawa/ClothsDaNaWaApplication.java
@@ -3,11 +3,9 @@ package com.example.clothsdanawa;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableCaching
 @SpringBootApplication
-@EnableJpaAuditing
 public class ClothsDaNaWaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/clothsdanawa/auth/controller/AuthController.java
+++ b/src/main/java/com/example/clothsdanawa/auth/controller/AuthController.java
@@ -7,8 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.clothsdanawa.auth.dto.AuthLoginRequestDto;
-import com.example.clothsdanawa.auth.dto.AuthResponseDto;
+import com.example.clothsdanawa.auth.dto.AuthLoginResponseDto;
 import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
+import com.example.clothsdanawa.auth.dto.AuthSignUpResponseDto;
 import com.example.clothsdanawa.auth.service.AuthService;
 
 import jakarta.validation.Valid;
@@ -22,14 +23,14 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/signup")
-	public ResponseEntity<AuthResponseDto> signup(@Valid @RequestBody AuthSignUpRequestDto authSignUpRequestDto) {
+	public ResponseEntity<AuthSignUpResponseDto> signup(@Valid @RequestBody AuthSignUpRequestDto authSignUpRequestDto) {
 
 		return ResponseEntity.status(201).body(authService.signup(authSignUpRequestDto));
 
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<AuthResponseDto> login(@RequestBody AuthLoginRequestDto authLoginRequestDto) {
+	public ResponseEntity<AuthLoginResponseDto> login(@RequestBody AuthLoginRequestDto authLoginRequestDto) {
 
 		return ResponseEntity.status(200).body(authService.login(authLoginRequestDto));
 

--- a/src/main/java/com/example/clothsdanawa/auth/dto/AuthLoginResponseDto.java
+++ b/src/main/java/com/example/clothsdanawa/auth/dto/AuthLoginResponseDto.java
@@ -7,20 +7,14 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class AuthResponseDto {
+public class AuthLoginResponseDto {
 	private Long id;
 	private String jwtToken;
 
-	public static AuthResponseDto of(User user, String jwtToken) {
-		return AuthResponseDto.builder()
+	public static AuthLoginResponseDto of(User user, String jwtToken) {
+		return AuthLoginResponseDto.builder()
 			.id(user.getUserId())
 			.jwtToken(jwtToken)
-			.build();
-	}
-
-	public static AuthResponseDto from(User user) {
-		return AuthResponseDto.builder()
-			.id(user.getUserId())
 			.build();
 	}
 }

--- a/src/main/java/com/example/clothsdanawa/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/clothsdanawa/auth/dto/AuthResponseDto.java
@@ -17,4 +17,10 @@ public class AuthResponseDto {
 			.jwtToken(jwtToken)
 			.build();
 	}
+
+	public static AuthResponseDto from(User user) {
+		return AuthResponseDto.builder()
+			.id(user.getUserId())
+			.build();
+	}
 }

--- a/src/main/java/com/example/clothsdanawa/auth/dto/AuthSignUpResponseDto.java
+++ b/src/main/java/com/example/clothsdanawa/auth/dto/AuthSignUpResponseDto.java
@@ -15,4 +15,10 @@ public class AuthSignUpResponseDto {
 			.id(user.getUserId())
 			.build();
 	}
+
+	public static AuthSignUpResponseDto of(Long id) {
+		return AuthSignUpResponseDto.builder()
+			.id(id)
+			.build();
+	}
 }

--- a/src/main/java/com/example/clothsdanawa/auth/dto/AuthSignUpResponseDto.java
+++ b/src/main/java/com/example/clothsdanawa/auth/dto/AuthSignUpResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.clothsdanawa.auth.dto;
+
+import com.example.clothsdanawa.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthSignUpResponseDto {
+	private Long id;
+
+	public static AuthSignUpResponseDto from(User user) {
+		return AuthSignUpResponseDto.builder()
+			.id(user.getUserId())
+			.build();
+	}
+}

--- a/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
+++ b/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
@@ -5,8 +5,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.example.clothsdanawa.auth.dto.AuthLoginRequestDto;
-import com.example.clothsdanawa.auth.dto.AuthResponseDto;
+import com.example.clothsdanawa.auth.dto.AuthLoginResponseDto;
 import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
+import com.example.clothsdanawa.auth.dto.AuthSignUpResponseDto;
 import com.example.clothsdanawa.common.exception.BaseException;
 import com.example.clothsdanawa.common.exception.ErrorCode;
 import com.example.clothsdanawa.common.jwt.JwtUtil;
@@ -23,7 +24,7 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
 
-	public AuthResponseDto signup(AuthSignUpRequestDto authSignUpRequestDto) {
+	public AuthSignUpResponseDto signup(AuthSignUpRequestDto authSignUpRequestDto) {
 
 		if (userRepository.existsByEmail(authSignUpRequestDto.getEmail())) {
 			throw new BaseException(ErrorCode.CONFLICT_EMAIL);
@@ -40,10 +41,10 @@ public class AuthService {
 			throw new BaseException(ErrorCode.CONFLICT_EMAIL);
 		}
 
-		return AuthResponseDto.from(savedUser);
+		return AuthSignUpResponseDto.from(savedUser);
 	}
 
-	public AuthResponseDto login(AuthLoginRequestDto authLoginRequestDto) {
+	public AuthLoginResponseDto login(AuthLoginRequestDto authLoginRequestDto) {
 
 		User findedUser = userRepository.findByEmailAndDeletedAtIsNullOrElseThrow(authLoginRequestDto.getEmail());
 		if (!passwordEncoder.matches(authLoginRequestDto.getPassword(), findedUser.getPassword())) {
@@ -53,6 +54,6 @@ public class AuthService {
 		String jwtToken = jwtUtil.createToken(findedUser.getUserId(), findedUser.getName(), findedUser.getEmail(),
 			findedUser.getUserRole());
 
-		return AuthResponseDto.of(findedUser, jwtToken);
+		return AuthLoginResponseDto.of(findedUser, jwtToken);
 	}
 }

--- a/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
+++ b/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.example.clothsdanawa.auth.service;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -34,12 +33,7 @@ public class AuthService {
 
 		User user = User.of(authSignUpRequestDto, encodedPassword);
 
-		User savedUser;
-		try {
-			savedUser = userRepository.save(user);
-		} catch (DataIntegrityViolationException e) {
-			throw new BaseException(ErrorCode.CONFLICT_EMAIL);
-		}
+		User savedUser = userRepository.save(user);
 
 		return AuthSignUpResponseDto.from(savedUser);
 	}

--- a/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
+++ b/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
@@ -34,10 +34,7 @@ public class AuthService {
 
 		User savedUser = userRepository.save(user);
 
-		String jwtToken = jwtUtil.createToken(savedUser.getUserId(), savedUser.getName(), savedUser.getEmail(),
-			savedUser.getUserRole());
-
-		return AuthResponseDto.of(savedUser, jwtToken);
+		return AuthResponseDto.from(savedUser);
 	}
 
 	public AuthResponseDto login(AuthLoginRequestDto authLoginRequestDto) {

--- a/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
+++ b/src/main/java/com/example/clothsdanawa/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.clothsdanawa.auth.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -32,7 +33,12 @@ public class AuthService {
 
 		User user = User.of(authSignUpRequestDto, encodedPassword);
 
-		User savedUser = userRepository.save(user);
+		User savedUser;
+		try {
+			savedUser = userRepository.save(user);
+		} catch (DataIntegrityViolationException e) {
+			throw new BaseException(ErrorCode.CONFLICT_EMAIL);
+		}
 
 		return AuthResponseDto.from(savedUser);
 	}

--- a/src/main/java/com/example/clothsdanawa/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/clothsdanawa/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	NOT_FOUND_USER_BY_ID(HttpStatus.NOT_FOUND, "USER_005", "아이디를 가진 사용자를 찾을 수 없습니다."),
 	CONFLICT_EMAIL(HttpStatus.CONFLICT, "USER_006", "이미 존재하는 이메일입니다"),
 	FORBIDDEN_NOT_CHANGE(HttpStatus.FORBIDDEN, "USER_007", "OAuth 유저는 비밀번호를 변경할 수 없습니다"),
+	CONFLICT_USER_DATA(HttpStatus.CONFLICT, "USER_008", "이미 있는 데이터 입니다."),
 
 	// product
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND,"PRODUCT_001", "해당 상품을 찾을 수 없습니다."),

--- a/src/main/java/com/example/clothsdanawa/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/clothsdanawa/common/exception/GlobalExceptionHandler.java
@@ -14,8 +14,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(EntityNotFoundException.class)
@@ -64,8 +66,10 @@ public class GlobalExceptionHandler {
 				if (constraintName.contains("uk_users_email")) {
 					return conflict(ErrorCode.CONFLICT_EMAIL);
 				}
+				log.warn("Unhandled constraint violation: {}", constraintName);
 			}
 		}
+		log.error("DataIntegrityViolationException without recognizable constraint", e);
 
 		return conflict(ErrorCode.CONFLICT_USER_DATA);
 	}

--- a/src/main/java/com/example/clothsdanawa/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/clothsdanawa/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -50,5 +52,33 @@ public class GlobalExceptionHandler {
 
 		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, errors);
 		return ResponseEntity.status(400).body(response);
+	}
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+
+		ConstraintViolationException cve = findHibernateConstraintViolation(e);
+		if (cve != null) {
+			String constraintName = cve.getConstraintName();
+			if (constraintName != null) {
+				if (constraintName.contains("uk_users_email")) {
+					return conflict(ErrorCode.CONFLICT_EMAIL);
+				}
+			}
+		}
+
+		return conflict(ErrorCode.CONFLICT_USER_DATA);
+	}
+
+	private ResponseEntity<ErrorResponse> conflict(ErrorCode errorCode) {
+		return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.from(errorCode));
+	}
+
+	private ConstraintViolationException findHibernateConstraintViolation(Throwable t) {
+		while (t != null) {
+			if (t instanceof ConstraintViolationException cve) return cve;
+			t = t.getCause();
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/example/clothsdanawa/common/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/example/clothsdanawa/common/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.example.clothsdanawa.common.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/clothsdanawa/product/entity/Product.java
+++ b/src/main/java/com/example/clothsdanawa/product/entity/Product.java
@@ -8,7 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE product SET deleted_at = NOW() WHERE id = ?")
-@Where(clause = "deleted_at IS NULL")
+@SQLRestriction("deleted_at IS NULL")
 public class Product {
 
 	/**

--- a/src/main/java/com/example/clothsdanawa/user/entity/User.java
+++ b/src/main/java/com/example/clothsdanawa/user/entity/User.java
@@ -8,7 +8,6 @@ import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
 import com.example.clothsdanawa.common.BaseEntity;
 import com.example.clothsdanawa.user.dto.UserUpdateRequestDto;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,6 +15,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +24,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-	name = "users"
+	name = "users",
+	uniqueConstraints = @UniqueConstraint(name = "uk_users_email", columnNames = "email")
 )
 @Getter
 @AllArgsConstructor
@@ -36,7 +37,6 @@ public class User extends BaseEntity {
 
 	private String name;
 
-	@Column(nullable = false, unique = true)
 	private String email;
 
 	private String password;

--- a/src/main/java/com/example/clothsdanawa/user/entity/User.java
+++ b/src/main/java/com/example/clothsdanawa/user/entity/User.java
@@ -8,12 +8,14 @@ import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
 import com.example.clothsdanawa.common.BaseEntity;
 import com.example.clothsdanawa.user.dto.UserUpdateRequestDto;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(
+	name = "users"
+)
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,6 +36,7 @@ public class User extends BaseEntity {
 
 	private String name;
 
+	@Column(nullable = false, unique = true)
 	private String email;
 
 	private String password;

--- a/src/test/java/com/example/clothsdanawa/MySQLContainerBaseTest.java
+++ b/src/test/java/com/example/clothsdanawa/MySQLContainerBaseTest.java
@@ -1,0 +1,30 @@
+package com.example.clothsdanawa;
+
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public abstract class MySQLContainerBaseTest {
+
+	@Container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+			.withDatabaseName("testdb")
+			.withUsername("test")
+			.withPassword("test");
+
+	@DynamicPropertySource
+	static void overrideProps(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mysql::getJdbcUrl);
+		registry.add("spring.datasource.username", mysql::getUsername);
+		registry.add("spring.datasource.password", mysql::getPassword);
+		registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+	}
+}

--- a/src/test/java/com/example/clothsdanawa/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/clothsdanawa/auth/controller/AuthControllerTest.java
@@ -56,8 +56,4 @@ class AuthControllerTest {
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.id").value(1L));
 	}
-
-	@Test
-	void login() {
-	}
 }

--- a/src/test/java/com/example/clothsdanawa/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/clothsdanawa/auth/controller/AuthControllerTest.java
@@ -1,0 +1,63 @@
+package com.example.clothsdanawa.auth.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
+import com.example.clothsdanawa.auth.dto.AuthSignUpResponseDto;
+import com.example.clothsdanawa.auth.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockitoBean
+	AuthService authService;
+
+	@Test
+	@DisplayName("회원가입 성공 시 상태코드 201과 응답에 id를 포함해주는지 확인")
+	void signup() throws Exception {
+		AuthSignUpRequestDto req = new AuthSignUpRequestDto(
+			"오병택",
+			"byeongtaek12@test.com",
+			"1234",
+			"test주소",
+			"user");
+
+		AuthSignUpResponseDto res = AuthSignUpResponseDto.of(1L);
+
+		given(authService.signup(any(AuthSignUpRequestDto.class)))
+			.willReturn(res);
+
+		mockMvc.perform(post("/auth/signup")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(req)))
+			.andExpect(status().isCreated())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.id").value(1L));
+	}
+
+	@Test
+	void login() {
+	}
+}

--- a/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.example.clothsdanawa.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.clothsdanawa.MySQLContainerBaseTest;
+import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
+import com.example.clothsdanawa.user.repository.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class AuthServiceIntegrationTest extends MySQLContainerBaseTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private AuthService authService;
+
+	@Test
+	@DisplayName("같은 이메일 동시 접근 시 예외가 발생")
+	void signup_fail_email_conflict() throws Exception {
+		int threadCount = 5;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch readyLatch = new CountDownLatch(threadCount);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger();
+		List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+		String sameEmail = "test1234@gmail.com";
+
+		for (int i = 0; i < threadCount; i++) {
+			int index = i;
+			executorService.submit(() -> {
+				readyLatch.countDown();
+				try {
+					startLatch.await();
+
+					AuthSignUpRequestDto req =  new AuthSignUpRequestDto(
+						"obt"+ index,
+						sameEmail,
+						"1234",
+						"test주소",
+						"user"
+					);
+
+					authService.signup(req);
+					successCount.incrementAndGet();
+				} catch (Throwable e) {
+					exceptions.add(e);
+				} finally {
+					doneLatch.countDown();
+				}
+			});
+		}
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await();
+
+		long userCount = userRepository.count();
+
+		assertThat(successCount.get()).isEqualTo(1);
+		assertThat(userCount).isEqualTo(1L);
+		assertThat(exceptions).hasSize(threadCount - 1);
+
+		executorService.shutdown();
+	}
+
+
+}

--- a/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceIntegrationTest.java
@@ -14,17 +14,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.example.clothsdanawa.MySQLContainerBaseTest;
 import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
+import com.example.clothsdanawa.common.exception.BaseException;
 import com.example.clothsdanawa.user.repository.UserRepository;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Transactional
 public class AuthServiceIntegrationTest extends MySQLContainerBaseTest {
 
 	@Autowired
@@ -46,44 +45,53 @@ public class AuthServiceIntegrationTest extends MySQLContainerBaseTest {
 		List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
 
 		String sameEmail = "test1234@gmail.com";
+		try {
+			for (int i = 0; i < threadCount; i++) {
+				int index = i;
+				executorService.submit(() -> {
+					readyLatch.countDown();
+					try {
+						startLatch.await();
 
-		for (int i = 0; i < threadCount; i++) {
-			int index = i;
-			executorService.submit(() -> {
-				readyLatch.countDown();
-				try {
-					startLatch.await();
+						AuthSignUpRequestDto req =  new AuthSignUpRequestDto(
+							"obt"+ index,
+							sameEmail,
+							"1234",
+							"test주소",
+							"user"
+						);
 
-					AuthSignUpRequestDto req =  new AuthSignUpRequestDto(
-						"obt"+ index,
-						sameEmail,
-						"1234",
-						"test주소",
-						"user"
-					);
+						authService.signup(req);
+						successCount.incrementAndGet();
+					} catch (Throwable e) {
+						exceptions.add(e);
+					} finally {
+						doneLatch.countDown();
+					}
+				});
+			}
 
-					authService.signup(req);
-					successCount.incrementAndGet();
-				} catch (Throwable e) {
-					exceptions.add(e);
-				} finally {
-					doneLatch.countDown();
-				}
-			});
+			readyLatch.await();
+			startLatch.countDown();
+			doneLatch.await();
+
+			long userCount = userRepository.count();
+
+			assertThat(successCount.get()).isEqualTo(1);
+			assertThat(userCount).isEqualTo(1L);
+			assertThat(exceptions).hasSize(threadCount - 1);
+
+			assertThat(exceptions)
+				.allSatisfy(e -> assertThat(e)
+					.isInstanceOfAny(
+						BaseException.class,
+						DataIntegrityViolationException.class
+					));
+		} finally {
+			executorService.shutdown();
+			if (!executorService.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS)) {
+				executorService.shutdownNow();
+			}
 		}
-
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await();
-
-		long userCount = userRepository.count();
-
-		assertThat(successCount.get()).isEqualTo(1);
-		assertThat(userCount).isEqualTo(1L);
-		assertThat(exceptions).hasSize(threadCount - 1);
-
-		executorService.shutdown();
 	}
-
-
 }

--- a/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceIntegrationTest.java
@@ -31,9 +31,6 @@ public class AuthServiceIntegrationTest extends MySQLContainerBaseTest {
 	private UserRepository userRepository;
 
 	@Autowired
-	private PasswordEncoder passwordEncoder;
-
-	@Autowired
 	private AuthService authService;
 
 	@Test

--- a/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/clothsdanawa/auth/service/AuthServiceTest.java
@@ -1,0 +1,65 @@
+package com.example.clothsdanawa.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.clothsdanawa.auth.dto.AuthSignUpRequestDto;
+import com.example.clothsdanawa.auth.dto.AuthSignUpResponseDto;
+import com.example.clothsdanawa.user.entity.User;
+import com.example.clothsdanawa.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Test
+	@DisplayName("정상적으로 토큰없이 반환되는지 확인")
+	void signup() {
+
+		//given
+		AuthSignUpRequestDto req = new AuthSignUpRequestDto(
+			"오병택",
+			"byeongtaek12@gmail.com",
+			"1234",
+			"test주소",
+			"user"
+		);
+
+		String encoded = "encodedPassword";
+
+		User user = User.of(req, encoded);
+		ReflectionTestUtils.setField(user, "userId", 1L);
+
+		given(userRepository.existsByEmail(req.getEmail())).willReturn(false);
+		given(passwordEncoder.encode(req.getPassword())).willReturn(encoded);
+		given(userRepository.save(any(User.class))).willReturn(user);
+
+		//when
+		AuthSignUpResponseDto response = authService.signup(req);
+
+		//then
+		assertThat(response.getId()).isEqualTo(1L);
+
+		verify(userRepository).existsByEmail(req.getEmail());
+		verify(passwordEncoder).encode(req.getPassword());
+		verify(userRepository).save(any(User.class));
+	}
+}

--- a/src/test/java/com/example/clothsdanawa/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/clothsdanawa/store/service/StoreServiceTest.java
@@ -1,60 +1,60 @@
-package com.example.clothsdanawa.store.service;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-
-import com.example.clothsdanawa.common.exception.BaseException;
-import com.example.clothsdanawa.store.entity.Store;
-import com.example.clothsdanawa.store.entity.StoreStatus;
-import com.example.clothsdanawa.store.repository.StoreRepository;
-import com.example.clothsdanawa.user.entity.User;
-import com.example.clothsdanawa.user.repository.UserRepository;
-
-@SpringBootTest
-class StoreServiceTest {
-
-	@Mock
-	private StoreRepository storeRepository;
-
-	@Mock
-	private UserRepository userRepository;
-
-	@InjectMocks
-	private StoreService storeService;
-
-	@Test
-	void closeStore_성공() {
-		User user = mock(User.class);
-		Store store = new Store(1L, "상호", StoreStatus.OPEN, "01033701620", "주소", user);
-
-		when(userRepository.findByEmailAndDeletedAtIsNullOrElseThrow(any())).thenReturn(user);
-
-		when(storeRepository.findByStoreIdOrElseThrow(any())).thenReturn(store);
-
-		storeService.closeStore(1L, "email");
-		assertEquals(StoreStatus.CLOSED, store.getStoreStatus());
-	}
-
-	@Test
-	void closeStore_실패_스토어_주인이_아님() {
-		User user1 = mock(User.class);
-		User user2 = mock(User.class);
-		Store store = new Store(1L, "상호", StoreStatus.OPEN, "01033701620", "주소", user1);
-
-		when(userRepository.findByEmailAndDeletedAtIsNullOrElseThrow(any())).thenReturn(user2);
-
-		when(storeRepository.findByStoreIdOrElseThrow(any())).thenReturn(store);
-
-		BaseException exception = assertThrows(BaseException.class, () -> {
-			storeService.closeStore(1L, "email");
-		});
-
-		assertEquals(HttpStatus.FORBIDDEN, exception.getErrorCode().getHttpStatus());
-	}
-}
+// package com.example.clothsdanawa.store.service;
+//
+// import static org.junit.jupiter.api.Assertions.*;
+// import static org.mockito.Mockito.*;
+//
+// import org.junit.jupiter.api.Test;
+// import org.mockito.InjectMocks;
+// import org.mockito.Mock;
+// import org.springframework.boot.test.context.SpringBootTest;
+// import org.springframework.http.HttpStatus;
+//
+// import com.example.clothsdanawa.common.exception.BaseException;
+// import com.example.clothsdanawa.store.entity.Store;
+// import com.example.clothsdanawa.store.entity.StoreStatus;
+// import com.example.clothsdanawa.store.repository.StoreRepository;
+// import com.example.clothsdanawa.user.entity.User;
+// import com.example.clothsdanawa.user.repository.UserRepository;
+//
+// @SpringBootTest
+// class StoreServiceTest {
+//
+// 	@Mock
+// 	private StoreRepository storeRepository;
+//
+// 	@Mock
+// 	private UserRepository userRepository;
+//
+// 	@InjectMocks
+// 	private StoreService storeService;
+//
+// 	@Test
+// 	void closeStore_성공() {
+// 		User user = mock(User.class);
+// 		Store store = new Store(1L, "상호", StoreStatus.OPEN, "01033701620", "주소", user);
+//
+// 		when(userRepository.findByEmailAndDeletedAtIsNullOrElseThrow(any())).thenReturn(user);
+//
+// 		when(storeRepository.findByStoreIdOrElseThrow(any())).thenReturn(store);
+//
+// 		storeService.closeStore(1L, "email");
+// 		assertEquals(StoreStatus.CLOSED, store.getStoreStatus());
+// 	}
+//
+// 	@Test
+// 	void closeStore_실패_스토어_주인이_아님() {
+// 		User user1 = mock(User.class);
+// 		User user2 = mock(User.class);
+// 		Store store = new Store(1L, "상호", StoreStatus.OPEN, "01033701620", "주소", user1);
+//
+// 		when(userRepository.findByEmailAndDeletedAtIsNullOrElseThrow(any())).thenReturn(user2);
+//
+// 		when(storeRepository.findByStoreIdOrElseThrow(any())).thenReturn(store);
+//
+// 		BaseException exception = assertThrows(BaseException.class, () -> {
+// 			storeService.closeStore(1L, "email");
+// 		});
+//
+// 		assertEquals(HttpStatus.FORBIDDEN, exception.getErrorCode().getHttpStatus());
+// 	}
+// }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+spring.application.name=ClothsDaNaWa-test
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+
+# test?? ??x
+jwt.secret.key="rxVnENG7E+y8ywLhlMWIzBZnE///x0AjXU3JedsCc8pgwXO/NCODZd6IUE5dWEaL5ehIYM7OlmJCvFfy0CDVVA=="

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -5,5 +5,5 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
-# test?? ??x
-jwt.secret.key="rxVnENG7E+y8ywLhlMWIzBZnE///x0AjXU3JedsCc8pgwXO/NCODZd6IUE5dWEaL5ehIYM7OlmJCvFfy0CDVVA=="
+# test??? ??x
+jwt.secret.key=rxVnENG7E+y8ywLhlMWIzBZnE///x0AjXU3JedsCc8pgwXO/NCODZd6IUE5dWEaL5ehIYM7OlmJCvFfy0CDVVA==


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 회원가입 서비스 로직에서 jwt 만들어주고 반환해주는 로직 제거
- 정적 팩터리 메서드 추가(id만 반환)
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 중복 이메일/데이터 제약 시 409 응답 처리 강화 및 제약명에 따른 구분 응답 추가(ErrorCode 및 예외 핸들러 수정)

* **리팩토링**
  * 회원가입/로그인 응답 타입 분리(회원가입은 ID 반환)
  * JPA 감사 설정을 구성 클래스로 이동
  * 사용자 테이블 명시 및 이메일 유니크 제약 추가, 소프트 삭제 필터링 방식 변경

* **테스트**
  * 단위 및 통합 테스트 추가(가입 단위/동시성 통합 테스트, Testcontainers 기반 MySQL 설정)
  * 일부 기존 테스트 파일 주석 처리 및 테스트 환경 프로퍼티 추가

* **빌드**
  * 테스트용 Testcontainers 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->