### PR TITLE
feat: 상품 키워드 기반 검색 API 구현

### DIFF
--- a/src/main/java/com/example/clothsdanawa/product/controller/ProductController.java
+++ b/src/main/java/com/example/clothsdanawa/product/controller/ProductController.java
@@ -5,11 +5,16 @@ import com.example.clothsdanawa.product.dto.request.ProductStockRequest;
 import com.example.clothsdanawa.product.dto.request.ProductUpdateRequest;
 import com.example.clothsdanawa.product.dto.response.ProductCreateResponse;
 import com.example.clothsdanawa.product.dto.response.ProductResponse;
+import com.example.clothsdanawa.product.dto.response.ProductSliceResponse;
 import com.example.clothsdanawa.product.dto.response.ProductStockResponse;
 import com.example.clothsdanawa.product.dto.response.ProductUpdateResponse;
 import com.example.clothsdanawa.product.entity.Product;
 import com.example.clothsdanawa.product.service.ProductService;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,6 +27,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/product")
+@Validated
 public class ProductController {
 
 	private final ProductService productService;
@@ -112,13 +118,12 @@ public class ProductController {
 	}
 
 	@GetMapping("/search")
-	public ProductResponse getProductByKeyword(
-		@RequestParam String keyword,
+	public ProductSliceResponse<ProductResponse> getProductByKeyword(
+		@RequestParam @NotBlank String keyword,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		Product searchProduct = productService.getProductByKeyword(keyword, page, size);
-		return new ProductResponse(searchProduct);
+		return productService.getProductByKeyword(keyword, page, size);
 	}
 }
 

--- a/src/main/java/com/example/clothsdanawa/product/controller/ProductController.java
+++ b/src/main/java/com/example/clothsdanawa/product/controller/ProductController.java
@@ -111,6 +111,14 @@ public class ProductController {
 		return new ProductStockResponse(updatedProduct);
 	}
 
-
+	@GetMapping("/search")
+	public ProductResponse getProductByKeyword(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Product searchProduct = productService.getProductByKeyword(keyword, page, size);
+		return new ProductResponse(searchProduct);
+	}
 }
 

--- a/src/main/java/com/example/clothsdanawa/product/dto/response/ProductSliceResponse.java
+++ b/src/main/java/com/example/clothsdanawa/product/dto/response/ProductSliceResponse.java
@@ -1,0 +1,15 @@
+package com.example.clothsdanawa.product.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductSliceResponse<T> {
+	private List<T> content;
+	private int page;
+	private int size;
+	private boolean hasNext;
+}

--- a/src/main/java/com/example/clothsdanawa/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/clothsdanawa/product/repository/ProductRepository.java
@@ -3,6 +3,8 @@ package com.example.clothsdanawa.product.repository;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -15,4 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	@Query("SELECT p FROM Product p Join fetch p.store WHERE p.productName LIKE %:keyword% AND p.deletedAt IS NULL "
 		+ "ORDER BY p.id DESC")
 	List<Product> searchTop10ProductByKeywordOrderByIdDesc(String keyword, Pageable pageRequest);
+
+	@EntityGraph(attributePaths = "store")
+	Slice<Product> findByProductNameContaining(String keyword, Pageable pageRequest);
 }

--- a/src/main/java/com/example/clothsdanawa/product/service/ProductService.java
+++ b/src/main/java/com/example/clothsdanawa/product/service/ProductService.java
@@ -3,12 +3,17 @@ package com.example.clothsdanawa.product.service;
 import com.example.clothsdanawa.common.exception.BaseException;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.clothsdanawa.common.exception.ErrorCode;
 import com.example.clothsdanawa.product.dto.request.ProductStockRequest;
 import com.example.clothsdanawa.product.dto.response.ProductResponse;
+import com.example.clothsdanawa.product.dto.response.ProductSliceResponse;
 import com.example.clothsdanawa.product.entity.Product;
 import com.example.clothsdanawa.product.enums.StockOperationType;
 import com.example.clothsdanawa.product.repository.ProductRepository;
@@ -25,6 +30,7 @@ import java.util.List;
  */
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProductService {
 
 	private final ProductRepository productRepository;
@@ -33,6 +39,7 @@ public class ProductService {
 	/**
 	 * 상품 등록
 	 */
+	@Transactional
 	public Long createProduct(Long storeId, String productName, int price, int stock) {
 		Store store = storeRepository.findById(storeId)
 			.orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND));
@@ -109,5 +116,18 @@ public class ProductService {
 		Product product = productRepository.findById(productId)
 			.orElseThrow(() -> new BaseException(ErrorCode.PRODUCT_NOT_FOUND));
 		return new ProductResponse(product);
+	}
+
+	public ProductSliceResponse<ProductResponse> getProductByKeyword(String keyword, int page, int size) {
+
+		Pageable pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+
+		Slice<Product> products = productRepository.findByProductNameContaining(keyword, pageRequest);
+
+		List<ProductResponse> responseList = products.getContent().stream()
+			.map(ProductResponse::new)
+			.toList();
+
+		return new ProductSliceResponse<>(responseList, products.getNumber(), products.getSize(), products.hasNext());
 	}
 }

--- a/src/test/java/com/example/clothsdanawa/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/clothsdanawa/product/service/ProductServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.clothsdanawa.product.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.clothsdanawa.product.dto.response.ProductResponse;
+import com.example.clothsdanawa.product.dto.response.ProductSliceResponse;
+import com.example.clothsdanawa.product.entity.Product;
+import com.example.clothsdanawa.product.repository.ProductRepository;
+import com.example.clothsdanawa.store.entity.Store;
+import com.example.clothsdanawa.store.entity.StoreStatus;
+import com.example.clothsdanawa.user.entity.User;
+import com.example.clothsdanawa.user.entity.UserRole;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+	@Mock
+	private ProductRepository productRepository;
+
+	@InjectMocks
+	private ProductService productService;
+
+	@Test
+	@DisplayName("데이터가 잘 조회 되는지 확인")
+	void getProductByKeyword() {
+		//given
+		String keyword = "바지";
+		int page = 0;
+		int size = 10;
+
+		PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+		User user = User.builder().name("문무겸비")
+			.email("byeongtaek12@gmail.com")
+			.password("1234")
+			.address("서울 어딘가")
+			.userRole(UserRole.USER)
+			.build();
+
+		ReflectionTestUtils.setField(user, "userId", 1L);
+
+		Store store = Store.builder().storeId(1L)
+			.company("완벽그자체인가게")
+			.storeStatus(StoreStatus.OPEN)
+			.storeNumber("010-1234-1234")
+			.address("서울 어딘가")
+			.user(user)
+			.build();
+		List<Product> productList = new ArrayList<>();
+
+		for (int i = 1; i <= 10; i++) {
+			Product product = new Product(store, "바지" + i, i * 1000, i * 10);
+			ReflectionTestUtils.setField(product, "id", (long)i);
+			productList.add(product);
+		}
+
+		Slice<Product> productSlice = new SliceImpl<>(productList, pageRequest, false);
+
+		given(productRepository.findByProductNameContaining(keyword, pageRequest)).willReturn(productSlice);
+
+		//when
+		ProductSliceResponse<ProductResponse> response = productService.getProductByKeyword(keyword, page, size);
+
+		//then
+		assertThat(response.getContent())
+			.extracting(ProductResponse::getProductName)
+			.containsExactlyElementsOf(
+				productList.stream()
+					.map(Product::getProductName)
+					.toList()
+			);
+		assertThat(response.getPage()).isEqualTo(0);
+		assertThat(response.getSize()).isEqualTo(10);
+		assertThat(response.isHasNext()).isEqualTo(false);
+	}
+}


### PR DESCRIPTION
- 일단은 controller 로직만 추가

## #️⃣연관된 이슈
#7 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 키워드 기반 상품 검색 엔드포인트 추가(/product/search). 키워드 필수이며 page, size 파라미터로 페이지 이동이 가능합니다.
  * 기본 페이지당 결과 10개, 검색 결과에 페이지 정보 및 다음 페이지 존재 여부(hasNext)를 포함합니다.

* **테스트**
  * 검색 동작 검증을 위한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->